### PR TITLE
Add custom prompts

### DIFF
--- a/drizzle-zero.config.ts
+++ b/drizzle-zero.config.ts
@@ -32,6 +32,7 @@ export default drizzleZeroConfig(drizzleSchema, {
       public: true,
       updatedAt: true,
       userId: true,
+      customInstructions: true,
     },
     chatTrees: {
       data: true,

--- a/drizzle/0000_daffy_cyclops.sql
+++ b/drizzle/0000_daffy_cyclops.sql
@@ -1,0 +1,92 @@
+CREATE TYPE "public"."message_status" AS ENUM('streaming', 'complete', 'aborted', 'error');--> statement-breakpoint
+CREATE TABLE "liquachat_account" (
+	"id" uuid PRIMARY KEY NOT NULL,
+	"userId" uuid NOT NULL,
+	"accountId" text NOT NULL,
+	"providerId" text NOT NULL,
+	"accessToken" text,
+	"refreshToken" text,
+	"idToken" text,
+	"accessTokenExpiresAt" timestamp,
+	"refreshTokenExpiresAt" timestamp,
+	"scope" text,
+	"password" text,
+	"createdAt" timestamp NOT NULL,
+	"updatedAt" timestamp NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "liquachat_chat_tree" (
+	"id" uuid PRIMARY KEY NOT NULL,
+	"userId" uuid NOT NULL,
+	"data" json
+);
+--> statement-breakpoint
+CREATE TABLE "liquachat_chat" (
+	"id" uuid PRIMARY KEY NOT NULL,
+	"title" text NOT NULL,
+	"public" boolean NOT NULL,
+	"userId" uuid NOT NULL,
+	"customInstructions" text,
+	"createdAt" timestamp NOT NULL,
+	"updatedAt" timestamp NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "liquachat_jwks" (
+	"id" uuid PRIMARY KEY NOT NULL,
+	"publicKey" text NOT NULL,
+	"privateKey" text NOT NULL,
+	"createdAt" timestamp NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "liquachat_message" (
+	"id" uuid PRIMARY KEY NOT NULL,
+	"chatId" uuid NOT NULL,
+	"userId" uuid,
+	"role" text NOT NULL,
+	"content" text NOT NULL,
+	"status" "message_status" NOT NULL,
+	"createdAt" timestamp NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "liquachat_session" (
+	"id" uuid PRIMARY KEY NOT NULL,
+	"userId" uuid NOT NULL,
+	"token" text NOT NULL,
+	"expiresAt" timestamp NOT NULL,
+	"ipAddress" text,
+	"userAgent" text,
+	"createdAt" timestamp NOT NULL,
+	"updatedAt" timestamp NOT NULL,
+	CONSTRAINT "liquachat_session_token_unique" UNIQUE("token")
+);
+--> statement-breakpoint
+CREATE TABLE "liquachat_user" (
+	"id" uuid PRIMARY KEY NOT NULL,
+	"name" text NOT NULL,
+	"email" text NOT NULL,
+	"emailVerified" boolean NOT NULL,
+	"image" text,
+	"isAnonymous" boolean,
+	"createdAt" timestamp NOT NULL,
+	"updatedAt" timestamp NOT NULL,
+	CONSTRAINT "liquachat_user_email_unique" UNIQUE("email")
+);
+--> statement-breakpoint
+CREATE TABLE "liquachat_verification" (
+	"id" uuid PRIMARY KEY NOT NULL,
+	"identifier" text NOT NULL,
+	"value" text NOT NULL,
+	"expiresAt" timestamp NOT NULL,
+	"createdAt" timestamp,
+	"updatedAt" timestamp
+);
+--> statement-breakpoint
+ALTER TABLE "liquachat_account" ADD CONSTRAINT "liquachat_account_userId_liquachat_user_id_fk" FOREIGN KEY ("userId") REFERENCES "public"."liquachat_user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "liquachat_chat_tree" ADD CONSTRAINT "liquachat_chat_tree_userId_liquachat_user_id_fk" FOREIGN KEY ("userId") REFERENCES "public"."liquachat_user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "liquachat_chat" ADD CONSTRAINT "liquachat_chat_userId_liquachat_user_id_fk" FOREIGN KEY ("userId") REFERENCES "public"."liquachat_user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "liquachat_message" ADD CONSTRAINT "liquachat_message_chatId_liquachat_chat_id_fk" FOREIGN KEY ("chatId") REFERENCES "public"."liquachat_chat"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "liquachat_message" ADD CONSTRAINT "liquachat_message_userId_liquachat_user_id_fk" FOREIGN KEY ("userId") REFERENCES "public"."liquachat_user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "liquachat_session" ADD CONSTRAINT "liquachat_session_userId_liquachat_user_id_fk" FOREIGN KEY ("userId") REFERENCES "public"."liquachat_user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "chat_user_id_idx" ON "liquachat_chat" USING btree ("userId");--> statement-breakpoint
+CREATE INDEX "message_chat_id_idx" ON "liquachat_message" USING btree ("chatId");--> statement-breakpoint
+CREATE INDEX "message_user_id_idx" ON "liquachat_message" USING btree ("userId");

--- a/drizzle/meta/0000_snapshot.json
+++ b/drizzle/meta/0000_snapshot.json
@@ -1,0 +1,617 @@
+{
+  "id": "a4ef6467-b13f-4b8c-877c-6926f48e7b49",
+  "prevId": "00000000-0000-0000-0000-000000000000",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.liquachat_account": {
+      "name": "liquachat_account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accountId": {
+          "name": "accountId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "providerId": {
+          "name": "providerId",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accessToken": {
+          "name": "accessToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refreshToken": {
+          "name": "refreshToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "idToken": {
+          "name": "idToken",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accessTokenExpiresAt": {
+          "name": "accessTokenExpiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refreshTokenExpiresAt": {
+          "name": "refreshTokenExpiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "liquachat_account_userId_liquachat_user_id_fk": {
+          "name": "liquachat_account_userId_liquachat_user_id_fk",
+          "tableFrom": "liquachat_account",
+          "tableTo": "liquachat_user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.liquachat_chat_tree": {
+      "name": "liquachat_chat_tree",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "json",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "liquachat_chat_tree_userId_liquachat_user_id_fk": {
+          "name": "liquachat_chat_tree_userId_liquachat_user_id_fk",
+          "tableFrom": "liquachat_chat_tree",
+          "tableTo": "liquachat_user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.liquachat_chat": {
+      "name": "liquachat_chat",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "public": {
+          "name": "public",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "customInstructions": {
+          "name": "customInstructions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "chat_user_id_idx": {
+          "name": "chat_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "liquachat_chat_userId_liquachat_user_id_fk": {
+          "name": "liquachat_chat_userId_liquachat_user_id_fk",
+          "tableFrom": "liquachat_chat",
+          "tableTo": "liquachat_user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.liquachat_jwks": {
+      "name": "liquachat_jwks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "publicKey": {
+          "name": "publicKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "privateKey": {
+          "name": "privateKey",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.liquachat_message": {
+      "name": "liquachat_message",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "chatId": {
+          "name": "chatId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "message_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "message_chat_id_idx": {
+          "name": "message_chat_id_idx",
+          "columns": [
+            {
+              "expression": "chatId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "message_user_id_idx": {
+          "name": "message_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "liquachat_message_chatId_liquachat_chat_id_fk": {
+          "name": "liquachat_message_chatId_liquachat_chat_id_fk",
+          "tableFrom": "liquachat_message",
+          "tableTo": "liquachat_chat",
+          "columnsFrom": [
+            "chatId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "liquachat_message_userId_liquachat_user_id_fk": {
+          "name": "liquachat_message_userId_liquachat_user_id_fk",
+          "tableFrom": "liquachat_message",
+          "tableTo": "liquachat_user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.liquachat_session": {
+      "name": "liquachat_session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ipAddress": {
+          "name": "ipAddress",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "userAgent": {
+          "name": "userAgent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "liquachat_session_userId_liquachat_user_id_fk": {
+          "name": "liquachat_session_userId_liquachat_user_id_fk",
+          "tableFrom": "liquachat_session",
+          "tableTo": "liquachat_user",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "liquachat_session_token_unique": {
+          "name": "liquachat_session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.liquachat_user": {
+      "name": "liquachat_user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "emailVerified": {
+          "name": "emailVerified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "isAnonymous": {
+          "name": "isAnonymous",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "liquachat_user_email_unique": {
+          "name": "liquachat_user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.liquachat_verification": {
+      "name": "liquachat_verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expiresAt": {
+          "name": "expiresAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.message_status": {
+      "name": "message_status",
+      "schema": "public",
+      "values": [
+        "streaming",
+        "complete",
+        "aborted",
+        "error"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -1,0 +1,13 @@
+{
+  "version": "7",
+  "dialect": "postgresql",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "7",
+      "when": 1755973496292,
+      "tag": "0000_daffy_cyclops",
+      "breakpoints": true
+    }
+  ]
+}

--- a/src/app/(chat)/chat/[chat-id]/page.tsx
+++ b/src/app/(chat)/chat/[chat-id]/page.tsx
@@ -1015,6 +1015,8 @@ function usePushAssistantMessage() {
       model?: string;
       reasoningEffort?: ReasoningEffort;
     }) => {
+      const chat = await z.query.chats.where("id", "=", chatId).one();
+      if (!chat) return;
       const messages = (
         await z.query.messages.where("chatId", "=", chatId)
       ).toSorted((a, b) => a.createdAt - b.createdAt);
@@ -1048,6 +1050,7 @@ function usePushAssistantMessage() {
                 reasoningEffort: input.reasoningEffort,
               }),
           abortSignal: abortController.signal,
+          customInstructions: chat.customInstructions ?? undefined,
         });
         for await (const chunk of response) {
           await z.mutate.chats.pushAssistantMessageChunk({

--- a/src/app/(chat)/layout.tsx
+++ b/src/app/(chat)/layout.tsx
@@ -19,7 +19,7 @@ import type { Key } from "react-aria-components";
 import { create } from "zustand";
 
 import { ChatTree } from "~/components/chat-tree";
-import { ChatCombobox } from "~/components/chat-tree-combobox";
+import { CustomizePromptDialog } from "~/components/customize-prompt-dialog";
 import { Logo } from "~/components/logo";
 import { Markdown } from "~/components/markdown";
 import { Button } from "~/components/system/button";
@@ -45,6 +45,7 @@ export default function Layout(props: { children: React.ReactNode }) {
         {children}
       </div>
       <ChatTelescope />
+      <CustomizePromptDialog />
     </div>
   );
 }

--- a/src/components/chat-tree.tsx
+++ b/src/components/chat-tree.tsx
@@ -13,6 +13,7 @@ import {
   FolderPlusIcon,
   MenuIcon,
   MessageSquareIcon,
+  Settings2Icon,
   TextCursorIcon,
   TrashIcon,
 } from "lucide-react";
@@ -41,6 +42,7 @@ import {
   ContextMenuSeparator,
   ContextMenuTrigger,
 } from "./context-menu";
+import { openCustomizePromptDialog } from "./customize-prompt-dialog";
 import { useRename } from "./rename-dialog";
 
 export interface ChatTreeProps {
@@ -350,6 +352,26 @@ function DynamicTreeItem(props: DynamicTreeItemProps) {
                     </ContextMenuItem>
                   )}
                   <ContextMenuSeparator />
+                  {item.kind === "chat" && (
+                    <>
+                      <ContextMenuItem
+                        onClick={async () => {
+                          const chat = await z.query.chats
+                            .where("id", "=", item.chatId)
+                            .one();
+                          if (!chat) return;
+                          openCustomizePromptDialog(
+                            item.chatId,
+                            chat.customInstructions ?? "",
+                          );
+                        }}
+                      >
+                        <Settings2Icon />
+                        Customize prompt
+                      </ContextMenuItem>
+                      <ContextMenuSeparator />
+                    </>
+                  )}
                   <ContextMenuItem
                     onClick={() => {
                       rename({

--- a/src/components/customize-prompt-dialog.tsx
+++ b/src/components/customize-prompt-dialog.tsx
@@ -68,7 +68,9 @@ export function CustomizePromptDialog() {
         if (!newOpen) {
           closeCustomizePromptDialog();
         } else {
-          openCustomizePromptDialog(chatId, initialValue);
+          dialogStore.setState({
+            open: true,
+          });
         }
       }}
     >

--- a/src/components/customize-prompt-dialog.tsx
+++ b/src/components/customize-prompt-dialog.tsx
@@ -1,0 +1,127 @@
+"use client";
+
+import * as React from "react";
+import { useForm } from "@tanstack/react-form";
+import { createStore, useStore } from "zustand";
+
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "~/components/system/dialog";
+import { useZero } from "~/zero/react";
+import { Button } from "./system/button";
+import { Textarea } from "./system/textarea";
+
+const dialogStore = createStore(() => ({
+  open: false,
+  chatId: "",
+  initialValue: "",
+}));
+
+export function openCustomizePromptDialog(
+  chatId: string,
+  initialValue: string,
+) {
+  dialogStore.setState({
+    open: true,
+    chatId,
+    initialValue,
+  });
+}
+
+export function closeCustomizePromptDialog() {
+  dialogStore.setState({
+    open: false,
+    chatId: "",
+    initialValue: "",
+  });
+}
+
+export function CustomizePromptDialog() {
+  const { open, initialValue, chatId } = useStore(dialogStore);
+  const z = useZero();
+  const form = useForm({
+    defaultValues: {
+      value: initialValue,
+    },
+    onSubmit: async ({ value, formApi }) => {
+      const newValue = value.value?.trim() || "";
+      await z.mutate.chats.update({
+        id: chatId,
+        customInstructions: newValue || null,
+      });
+      closeCustomizePromptDialog();
+      formApi.reset();
+    },
+  });
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(newOpen) => {
+        form.reset();
+        if (!newOpen) {
+          closeCustomizePromptDialog();
+        } else {
+          openCustomizePromptDialog(chatId, initialValue);
+        }
+      }}
+    >
+      <DialogContent className="sm:max-w-[600px]" autoFocus>
+        {open && (
+          <form
+            onSubmit={(event) => {
+              event.preventDefault();
+              event.stopPropagation();
+              void form.handleSubmit();
+            }}
+          >
+            <DialogHeader>
+              <DialogTitle>Customize System Prompt</DialogTitle>
+              <DialogDescription>
+                You can customize the system prompt for this chat. These custom
+                instructions will be injected directly into the system prompt.
+                They take priority over the default behavior and can override
+                any existing directive. Leave empty to use the default system
+                prompt.
+              </DialogDescription>
+            </DialogHeader>
+            <form.Field
+              name="value"
+              children={(field) => (
+                <Textarea
+                  placeholder="Enter custom instructions for this chat..."
+                  value={field.state.value}
+                  onChange={(e) => {
+                    field.handleChange(e.target.value);
+                  }}
+                  onBlur={field.handleBlur}
+                  rows={6}
+                  className="mt-3.5 mb-4.5"
+                />
+              )}
+            />
+            <DialogFooter>
+              <DialogClose asChild>
+                <Button variant="ghost">Cancel</Button>
+              </DialogClose>
+              <form.Subscribe
+                selector={(state) => [state.canSubmit]}
+                children={([canSubmit]) => (
+                  <Button type="submit" disabled={!canSubmit}>
+                    Save changes
+                  </Button>
+                )}
+              />
+            </DialogFooter>
+          </form>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/system/textarea.tsx
+++ b/src/components/system/textarea.tsx
@@ -1,0 +1,18 @@
+import * as React from "react";
+
+import { cn } from "~/lib/cn";
+
+function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
+  return (
+    <textarea
+      data-slot="textarea"
+      className={cn(
+        "placeholder:text-muted-foreground focus-visible:border-primary/70 focus-visible:ring-primary/70 aria-invalid:ring-destructive/20 aria-invalid:border-destructive flex field-sizing-content min-h-16 w-full rounded-md border bg-transparent px-3 py-2 text-base shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export { Textarea };

--- a/src/lib/ai.ts
+++ b/src/lib/ai.ts
@@ -9,7 +9,10 @@ import type { ZeroRow } from "~/zero/schema";
 
 export type ReasoningEffort = "low" | "medium" | "high";
 
-export type StreamResponseOptions = { abortSignal: AbortSignal } & (
+export type StreamResponseOptions = {
+  abortSignal: AbortSignal;
+  customInstructions?: string;
+} & (
   | {
       provider: "ollama";
       modelId: string;
@@ -44,6 +47,14 @@ export function streamResponse(
           "- Do not use emojis unless they are explicitly requested.",
           "- Be concise and to the point by default. Provide more details only when explicitly requested.",
           "</core-directives>",
+          ...(options.customInstructions
+            ? [
+                "You MUST also follow the following instructions, that take priority over the core directives above",
+                "<instructions>",
+                options.customInstructions,
+                "</instructions>",
+              ]
+            : []),
         ].join("\n"),
       },
       ...messages.map(

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -44,6 +44,7 @@ export const chats = createTable(
       .uuid()
       .notNull()
       .references(() => users.id, { onDelete: "cascade" }),
+    customInstructions: d.text(),
     createdAt: d.timestamp().notNull(),
     updatedAt: d.timestamp().notNull(),
   }),

--- a/src/zero/schema.gen.ts
+++ b/src/zero/schema.gen.ts
@@ -97,6 +97,15 @@ export const schema = {
             "userId"
           >,
         },
+        customInstructions: {
+          type: "string",
+          optional: true,
+          customType: null as unknown as ZeroCustomType<
+            typeof zeroSchema,
+            "chats",
+            "customInstructions"
+          >,
+        },
         createdAt: {
           type: "number",
           optional: false,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Customize prompt” dialog to set per-chat custom instructions (edit, save, or clear a chat-specific system prompt).
  * New “Customize prompt” option in chat context menus and layout for quick access.
  * Assistant responses now respect and prioritize saved custom instructions per chat.

* **Chores**
  * Database schema and migration added to persist per-chat custom instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->